### PR TITLE
Synchronisation simplification/overhaul based on vk-sync-rs

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -16,7 +16,7 @@ pub struct Pipeline {
 #[sierra::pass]
 #[subpass(color = target)]
 pub struct Main {
-    #[attachment(clear(const sierra::ClearColor(0.3, 0.1, 0.8, 1.0)), store(const sierra::Layout::Present))]
+    #[attachment(clear(const sierra::ClearColor(0.3, 0.1, 0.8, 1.0)), store(const sierra::RawLayout::Present))]
     target: sierra::Image,
 }
 

--- a/proc/src/pass/instance.rs
+++ b/proc/src/pass/instance.rs
@@ -18,7 +18,7 @@ pub(super) fn generate(input: &Input) -> TokenStream {
 
             let initial_layout = initial_layout(&a.load_op);
             let check_final_layout = final_layout(&a.store_op).map(|final_layout| {
-                quote::quote!(else if a.final_layout != ::sierra::Layout::from(#final_layout) {
+                quote::quote!(else if a.final_layout != ::sierra::RawLayout::from(#final_layout) {
                     tracing::debug!("Final layout is incompatible. Old {:?}, new {:?}", a.final_layout, #final_layout);
                     render_pass_compatible = false;
                 } )
@@ -34,8 +34,8 @@ pub(super) fn generate(input: &Input) -> TokenStream {
                         tracing::debug!("Samples count is incompatible. Old {:?}, new {:?}", a.samples, ::sierra::Attachment::samples(&input.#member));
                         render_pass_compatible = false;
                     }
-                } else if a.initial_layout != ::std::option::Option::map(#initial_layout, ::sierra::Layout::from) {
-                    tracing::debug!("Initial layout is incompatible. Old {:?}, new {:?}", a.initial_layout, ::std::option::Option::map(#initial_layout, ::sierra::Layout::from));
+                } else if a.initial_layout != ::std::option::Option::map(#initial_layout, ::sierra::RawLayout::from) {
+                    tracing::debug!("Initial layout is incompatible. Old {:?}, new {:?}", a.initial_layout, ::std::option::Option::map(#initial_layout, ::sierra::RawLayout::from));
                     render_pass_compatible = false;
                 } #check_final_layout
             )
@@ -65,10 +65,10 @@ pub(super) fn generate(input: &Input) -> TokenStream {
                         .iter()
                         .filter_map(|s| {
                             if s.colors.iter().any(|&c| c == index) {
-                                Some(quote::quote!(::sierra::Layout::ColorAttachmentOptimal))
+                                Some(quote::quote!(::sierra::RawLayout::ColorAttachmentOptimal))
                             } else if s.depth == Some(index) {
                                 Some(quote::quote!(
-                                    ::sierra::Layout::DepthStencilAttachmentOptimal
+                                    ::sierra::RawLayout::DepthStencilAttachmentOptimal
                                 ))
                             } else {
                                 None
@@ -76,7 +76,7 @@ pub(super) fn generate(input: &Input) -> TokenStream {
                         })
                         .rev()
                         .next()
-                        .unwrap_or_else(|| quote::quote!(::sierra::Layout::General))
+                        .unwrap_or_else(|| quote::quote!(::sierra::RawLayout::General))
                 }
                 Some(layout) => layout,
             };
@@ -107,7 +107,7 @@ pub(super) fn generate(input: &Input) -> TokenStream {
                 .colors
                 .iter()
                 .map(
-                    |&c| quote::quote!(colors.push((#c, ::sierra::Layout::ColorAttachmentOptimal));),
+                    |&c| quote::quote!(colors.push((#c, ::sierra::RawLayout::ColorAttachmentOptimal));),
                 )
                 .collect::<TokenStream>();
 
@@ -122,7 +122,7 @@ pub(super) fn generate(input: &Input) -> TokenStream {
                                 #push_colors
                                 colors
                             },
-                            depth: Some((#depth, ::sierra::Layout::DepthStencilAttachmentOptimal)),
+                            depth: Some((#depth, ::sierra::RawLayout::DepthStencilAttachmentOptimal)),
                         });
                     )
                 }

--- a/src/access.rs
+++ b/src/access.rs
@@ -1,139 +1,148 @@
-bitflags::bitflags! {
-    /// Flags for access types.
-    pub struct AccessFlags: u32 {
-        /// Read access to indirect command data
-        /// read as part of an indirect build,
-        /// trace, drawing or dispatch command.
-        const INDIRECT_COMMAND_READ = 0x00000001;
+// Modified from vk-sync-rs, originally Copyright 2019 Graham Wihlidal
+// licensed under MIT license.
+//
+// https://github.com/gwihlidal/vk-sync-rs/blob/master/LICENSE-MIT
 
-        /// Read access to an index buffer as part of an indexed drawing command
-        const INDEX_READ = 0x00000002;
+/// Defines all potential resource usages
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash,)]
+pub enum Access {
+	/// No access. Useful primarily for initialization
+	None,
 
-        /// Read access to a vertex buffer as part of a drawing command
-        const VERTEX_ATTRIBUTE_READ = 0x00000004;
+	/// Read as an indirect buffer for drawing or dispatch
+	IndirectBuffer,
 
-        /// Read access to a uniform buffer..
-        const UNIFORM_READ = 0x00000008;
+	/// Read as an index buffer for drawing
+	IndexBuffer,
 
-        /// Read access to an input attachment
-        /// within a render pass during fragment shading.
-        const INPUT_ATTACHMENT_READ = 0x00000010;
+	/// Read as a vertex buffer for drawing
+	VertexBuffer,
 
-        /// Read access to a storage buffer, physical storage buffer,
-        /// shader binding table, uniform texel buffer, storage texel buffer,
-        /// sampled image, or storage image.
-        const SHADER_READ = 0x00000020;
+	/// Read as a uniform buffer in a vertex shader
+	VertexShaderReadUniformBuffer,
 
-        /// Write access to a storage buffer, physical storage buffer,
-        /// storage texel buffer, or storage image.
-        const SHADER_WRITE = 0x00000040;
+	/// Read as a sampled image/uniform texel buffer in a vertex shader
+	VertexShaderReadSampledImageOrUniformTexelBuffer,
 
-        /// Read access to a color attachment,
-        /// such as via blending, logic operations,
-        /// or via certain subpass load operations.\
-        /// It does not include advanced blend operations.
-        const COLOR_ATTACHMENT_READ = 0x00000080;
+	/// Read as any other resource in a vertex shader
+	VertexShaderReadOther,
 
-        /// Write access to a color, resolve,
-        /// or depth/stencil resolve attachment
-        /// during a render pass
-        /// or via certain subpass load and store operations.
-        const COLOR_ATTACHMENT_WRITE = 0x00000100;
+	/// Read as a uniform buffer in a fragment shader
+	FragmentShaderReadUniformBuffer,
 
-        /// Read access to a depth/stencil attachment,
-        /// via depth or stencil operations
-        /// or via certain subpass load operations.
-        const DEPTH_STENCIL_ATTACHMENT_READ = 0x00000200;
+	/// Read as a sampled image/uniform texel buffer in a fragment shader
+	FragmentShaderReadSampledImageOrUniformTexelBuffer,
 
-        /// Write access to a depth/stencil attachment,
-        /// via depth or stencil operations
-        /// or via certain subpass load and store operations.
-        const DEPTH_STENCIL_ATTACHMENT_WRITE = 0x00000400;
+	/// Read as an input attachment with a color format in a fragment shader
+	FragmentShaderReadColorInputAttachment,
 
-        /// Read access to an image or buffer in a copy operation.
-        const TRANSFER_READ = 0x00000800;
+	/// Read as an input attachment with a depth/stencil format in a fragment shader
+	FragmentShaderReadDepthStencilInputAttachment,
 
-        /// Write access to an image or buffer in a clear or copy operation.
-        const TRANSFER_WRITE = 0x00001000;
+	/// Read as any other resource in a fragment shader
+	FragmentShaderReadOther,
 
-        /// Read access by a host operation.
-        const HOST_READ = 0x00002000;
+	/// Read by blending/logic operations or subpass load operations
+	ColorAttachmentRead,
 
-        /// Write access by a host operation.
-        const HOST_WRITE = 0x00004000;
+	/// Read by depth/stencil tests or subpass load operations
+	DepthStencilAttachmentRead,
 
-        /// All read accesses.
-        const MEMORY_READ = 0x00008000;
+	/// Read as a uniform buffer in a compute shader
+	ComputeShaderReadUniformBuffer,
 
-        /// All write accesses.
-        const MEMORY_WRITE = 0x00010000;
+	/// Read as a sampled image/uniform texel buffer in a compute shader
+	ComputeShaderReadSampledImageOrUniformTexelBuffer,
 
-        // /// Write access to a transform feedback buffer made
-        // /// when transform feedback is active.
-        // const TRANSFORM_FEEDBACK_WRITE = 0x00020000;
+	/// Read as any other resource in a compute shader
+	ComputeShaderReadOther,
 
-        // /// Read access to a transform feedback counter buffer
-        // /// which is read when vkCmdBeginTransformFeedbackEXT executes.
-        // const TRANSFORM_FEEDBACK_COUNTER_READ = 0x00040000;
+	/// Read as a uniform buffer in any shader
+	AnyShaderReadUniformBuffer,
 
-        // /// Write access to a transform feedback counter buffer
-        // /// which is written when vkCmdEndTransformFeedbackEXT executes.
-        // const TRANSFORM_FEEDBACK_COUNTER_WRITE = 0x00080000;
+	/// Read as a uniform buffer in any shader, or a vertex buffer
+	AnyShaderReadUniformBufferOrVertexBuffer,
 
-        /// Read access to a predicate as part of conditional rendering.
-        const CONDITIONAL_RENDERING_READ = 0x00100000;
+	/// Read as a sampled image in any shader
+	AnyShaderReadSampledImageOrUniformTexelBuffer,
 
-        /// Similar to [`COLOR_ATTACHMENT_READ`],
-        /// but also includes advanced blend operations.
-        const COLOR_ATTACHMENT_READ_NONCOHERENT = 0x00200000;
+	/// Read as any other resource (excluding attachments) in any shader
+	AnyShaderReadOther,
 
-        /// Read access to an acceleration structure
-        /// as part of a trace, build, or copy command,
-        /// or to an acceleration structure scratch buffer
-        // as part of a build command.
-        const ACCELERATION_STRUCTURE_READ = 0x00400000;
+	/// Read as the source of a transfer operation
+	TransferRead,
 
-        /// Write access to an acceleration structure
-        /// or acceleration structure scratch buffer
-        /// as part of a build or copy command.
-        const ACCELERATION_STRUCTURE_WRITE = 0x00800000;
+	/// Read on the host
+	HostRead,
 
-        /// Read access to a fragment density map attachment
-        /// during dynamic fragment density map operations.
-        const FRAGMENT_DENSITY_MAP_READ = 0x01000000;
+	/// Read by the presentation engine (i.e. `vkQueuePresentKHR`)
+	Present,
 
-        /// Read access to a fragment shading rate attachment
-        /// or shading rate image during rasterization.
-        const FRAGMENT_SHADING_RATE_ATTACHMENT_READ = 0x02000000;
-    }
+	/// Written as any resource in a vertex shader
+	VertexShaderWrite,
+
+	/// Written as any resource in a fragment shader
+	FragmentShaderWrite,
+
+	/// Written as a color attachment during rendering, or via a subpass store op
+	ColorAttachmentWrite,
+
+	/// Written as a depth/stencil attachment during rendering, or via a subpass store op
+	DepthStencilAttachmentWrite,
+
+	/// Written as a depth aspect of a depth/stencil attachment during rendering, whilst the
+	/// stencil aspect is read-only. Requires `VK_KHR_maintenance2` to be enabled.
+	DepthAttachmentWriteStencilReadOnly,
+
+	/// Written as a stencil aspect of a depth/stencil attachment during rendering, whilst the
+	/// depth aspect is read-only. Requires `VK_KHR_maintenance2` to be enabled.
+	StencilAttachmentWriteDepthReadOnly,
+
+	/// Written as any resource in a compute shader
+	ComputeShaderWrite,
+
+	/// Written as any resource in any shader
+	AnyShaderWrite,
+
+	/// Written as the destination of a transfer operation
+	TransferWrite,
+
+	/// Written on the host
+	HostWrite,
+
+	/// Read or written as a color attachment during rendering
+	ColorAttachmentReadWrite,
+
+	/// Covers any access - useful for debug, generally avoid for performance reasons
+	General,
 }
 
-impl AccessFlags {
-    pub fn is_read(self) -> bool {
-        self.intersects(
-            Self::SHADER_READ
-                | Self::COLOR_ATTACHMENT_READ
-                | Self::DEPTH_STENCIL_ATTACHMENT_READ
-                | Self::TRANSFER_READ
-                | Self::HOST_READ
-                | Self::MEMORY_READ
-                // | Self::TRANSFORM_FEEDBACK_READ
-                // | Self::TRANSFORM_FEEDBACK_COUNTER_READ
-                | Self::ACCELERATION_STRUCTURE_READ,
-        )
-    }
+impl Default for Access {
+	fn default() -> Self {
+		Access::None
+	}
+}
 
-    pub fn is_write(self) -> bool {
-        self.intersects(
-            Self::SHADER_WRITE
-                | Self::COLOR_ATTACHMENT_WRITE
-                | Self::DEPTH_STENCIL_ATTACHMENT_WRITE
-                | Self::TRANSFER_WRITE
-                | Self::HOST_WRITE
-                | Self::MEMORY_WRITE
-                // | Self::TRANSFORM_FEEDBACK_WRITE
-                // | Self::TRANSFORM_FEEDBACK_COUNTER_WRITE
-                | Self::ACCELERATION_STRUCTURE_WRITE,
-        )
-    }
+impl Access {
+	pub fn is_write(self) -> bool {
+		match self {
+			Access::VertexShaderWrite => true,
+			Access::FragmentShaderWrite => true,
+			Access::ColorAttachmentWrite => true,
+			Access::DepthStencilAttachmentWrite => true,
+			Access::DepthAttachmentWriteStencilReadOnly => true,
+			Access::StencilAttachmentWriteDepthReadOnly => true,
+			Access::ComputeShaderWrite => true,
+			Access::AnyShaderWrite => true,
+			Access::TransferWrite => true,
+			Access::HostWrite => true,
+			Access::ColorAttachmentReadWrite => true,
+			Access::General => true,
+			_ => false,
+		}
+	}
+
+	pub fn is_read_only(self) -> bool {
+		!self.is_write()
+	}
 }

--- a/src/backend/vulkan/access.rs
+++ b/src/backend/vulkan/access.rs
@@ -1,5 +1,7 @@
 use erupt::vk1_0;
 
+use crate::Access;
+
 fn supported_stages_inner(access: vk1_0::AccessFlags) -> vk1_0::PipelineStageFlags {
     type AF = vk1_0::AccessFlags;
     type PS = vk1_0::PipelineStageFlags;
@@ -67,4 +69,209 @@ pub(crate) fn supported_access(stages: vk1_0::PipelineStageFlags) -> vk1_0::Acce
     }
 
     result
+}
+
+pub(crate) struct AccessInfo {
+	pub(crate) stage_mask: vk1_0::PipelineStageFlags,
+	pub(crate) access_mask: vk1_0::AccessFlags,
+	pub(crate) image_layout: vk1_0::ImageLayout,
+}
+
+pub(crate) trait GetAccessInfo {
+    fn access_info(self) -> AccessInfo;
+}
+
+impl GetAccessInfo for Access {
+	fn access_info(self) -> AccessInfo {
+        match self {
+            Access::None => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::empty(),
+                access_mask: vk1_0::AccessFlags::empty(),
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::IndirectBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::DRAW_INDIRECT,
+                access_mask: vk1_0::AccessFlags::INDIRECT_COMMAND_READ,
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::IndexBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::VERTEX_INPUT,
+                access_mask: vk1_0::AccessFlags::INDEX_READ,
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::VertexBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::VERTEX_INPUT,
+                access_mask: vk1_0::AccessFlags::VERTEX_ATTRIBUTE_READ,
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::VertexShaderReadUniformBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::VERTEX_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::VertexShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::VERTEX_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            },
+            Access::VertexShaderReadOther => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::VERTEX_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::FragmentShaderReadUniformBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::FRAGMENT_SHADER,
+                access_mask: vk1_0::AccessFlags::UNIFORM_READ,
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::FragmentShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::FRAGMENT_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            },
+            Access::FragmentShaderReadColorInputAttachment => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::FRAGMENT_SHADER,
+                access_mask: vk1_0::AccessFlags::INPUT_ATTACHMENT_READ,
+                image_layout: vk1_0::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            },
+            Access::FragmentShaderReadDepthStencilInputAttachment => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::FRAGMENT_SHADER,
+                access_mask: vk1_0::AccessFlags::INPUT_ATTACHMENT_READ,
+                image_layout: vk1_0::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+            },
+            Access::FragmentShaderReadOther => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::FRAGMENT_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::ColorAttachmentRead => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+                access_mask: vk1_0::AccessFlags::COLOR_ATTACHMENT_READ,
+                image_layout: vk1_0::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            },
+            Access::DepthStencilAttachmentRead => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+                    | vk1_0::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+                access_mask: vk1_0::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
+                image_layout: vk1_0::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+            },
+            Access::ComputeShaderReadUniformBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::COMPUTE_SHADER,
+                access_mask: vk1_0::AccessFlags::UNIFORM_READ,
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::ComputeShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::COMPUTE_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            },
+            Access::ComputeShaderReadOther => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::COMPUTE_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::AnyShaderReadUniformBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::ALL_COMMANDS,
+                access_mask: vk1_0::AccessFlags::UNIFORM_READ,
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::AnyShaderReadUniformBufferOrVertexBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::ALL_COMMANDS,
+                access_mask: vk1_0::AccessFlags::UNIFORM_READ
+                    | vk1_0::AccessFlags::VERTEX_ATTRIBUTE_READ,
+                image_layout: vk1_0::ImageLayout::UNDEFINED,
+            },
+            Access::AnyShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::ALL_COMMANDS,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            },
+            Access::AnyShaderReadOther => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::ALL_COMMANDS,
+                access_mask: vk1_0::AccessFlags::SHADER_READ,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::TransferRead => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::TRANSFER,
+                access_mask: vk1_0::AccessFlags::TRANSFER_READ,
+                image_layout: vk1_0::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            },
+            Access::HostRead => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::HOST,
+                access_mask: vk1_0::AccessFlags::HOST_READ,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::Present => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::empty(),
+                access_mask: vk1_0::AccessFlags::empty(),
+                image_layout: vk1_0::ImageLayout::PRESENT_SRC_KHR,
+            },
+            Access::VertexShaderWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::VERTEX_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_WRITE,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::FragmentShaderWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::FRAGMENT_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_WRITE,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::ColorAttachmentWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+                access_mask: vk1_0::AccessFlags::COLOR_ATTACHMENT_WRITE,
+                image_layout: vk1_0::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            },
+            Access::DepthStencilAttachmentWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+                    | vk1_0::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+                access_mask: vk1_0::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                image_layout: vk1_0::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+            },
+            Access::DepthAttachmentWriteStencilReadOnly => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+                    | vk1_0::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+                access_mask: vk1_0::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
+                    | vk1_0::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
+                image_layout: vk1_0::ImageLayout::DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
+            },
+            Access::StencilAttachmentWriteDepthReadOnly => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+                    | vk1_0::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+                access_mask: vk1_0::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
+                    | vk1_0::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
+                image_layout: vk1_0::ImageLayout::DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
+            },
+            Access::ComputeShaderWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::COMPUTE_SHADER,
+                access_mask: vk1_0::AccessFlags::SHADER_WRITE,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::AnyShaderWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::ALL_COMMANDS,
+                access_mask: vk1_0::AccessFlags::SHADER_WRITE,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::TransferWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::TRANSFER,
+                access_mask: vk1_0::AccessFlags::TRANSFER_WRITE,
+                image_layout: vk1_0::ImageLayout::TRANSFER_DST_OPTIMAL,
+            },
+            Access::HostWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::HOST,
+                access_mask: vk1_0::AccessFlags::HOST_WRITE,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+            Access::ColorAttachmentReadWrite => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+                access_mask: vk1_0::AccessFlags::COLOR_ATTACHMENT_READ
+                    | vk1_0::AccessFlags::COLOR_ATTACHMENT_WRITE,
+                image_layout: vk1_0::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            },
+            Access::General => AccessInfo {
+                stage_mask: vk1_0::PipelineStageFlags::ALL_COMMANDS,
+                access_mask: vk1_0::AccessFlags::MEMORY_READ | vk1_0::AccessFlags::MEMORY_WRITE,
+                image_layout: vk1_0::ImageLayout::GENERAL,
+            },
+        }
+	}
 }

--- a/src/backend/vulkan/convert.rs
+++ b/src/backend/vulkan/convert.rs
@@ -1,10 +1,10 @@
 use crate::{
-    out_of_host_memory, AccelerationStructureBuildFlags, AccelerationStructureLevel, AccessFlags,
+    out_of_host_memory, AccelerationStructureBuildFlags, AccelerationStructureLevel,
     AspectFlags, BlendFactor, BlendOp, BorderColor, BufferCopy, BufferImageCopy, BufferUsage,
     CompareOp, ComponentMask, CompositeAlphaFlags, Culling, DescriptorBindingFlags,
     DescriptorSetLayoutFlags, DescriptorType, DeviceAddress, Extent2d, Extent3d, Filter, Format,
     FrontFace, GeometryFlags, ImageBlit, ImageCopy, ImageExtent, ImageUsage, ImageViewKind,
-    IndexType, Layout, LoadOp, LogicOp, MemoryUsage, MipmapMode, Offset2d, Offset3d, OutOfMemory,
+    IndexType, RawLayout, LoadOp, LogicOp, MemoryUsage, MipmapMode, Offset2d, Offset3d, OutOfMemory,
     PipelineStageFlags, PolygonMode, PresentMode, PrimitiveTopology, QueueCapabilityFlags, Rect2d,
     SamplerAddressMode, Samples, ShaderStage, ShaderStageFlags, StencilOp, StoreOp, Subresource,
     SubresourceLayers, SubresourceRange, SurfaceTransformFlags, VertexInputRate, Viewport,
@@ -990,26 +990,26 @@ impl ToErupt<vk1_0::ColorComponentFlags> for ComponentMask {
     }
 }
 
-impl ToErupt<vk1_0::ImageLayout> for Layout {
+impl ToErupt<vk1_0::ImageLayout> for RawLayout {
     fn to_erupt(self) -> vk1_0::ImageLayout {
         match self {
-            Layout::General => vk1_0::ImageLayout::GENERAL,
-            Layout::ColorAttachmentOptimal => vk1_0::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
-            Layout::DepthStencilAttachmentOptimal => {
+            RawLayout::General => vk1_0::ImageLayout::GENERAL,
+            RawLayout::ColorAttachmentOptimal => vk1_0::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            RawLayout::DepthStencilAttachmentOptimal => {
                 vk1_0::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
             }
-            Layout::DepthStencilReadOnlyOptimal => {
+            RawLayout::DepthStencilReadOnlyOptimal => {
                 vk1_0::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL
             }
-            Layout::ShaderReadOnlyOptimal => vk1_0::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
-            Layout::TransferSrcOptimal => vk1_0::ImageLayout::TRANSFER_SRC_OPTIMAL,
-            Layout::TransferDstOptimal => vk1_0::ImageLayout::TRANSFER_DST_OPTIMAL,
-            Layout::Present => vk1_0::ImageLayout::PRESENT_SRC_KHR,
+            RawLayout::ShaderReadOnlyOptimal => vk1_0::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            RawLayout::TransferSrcOptimal => vk1_0::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            RawLayout::TransferDstOptimal => vk1_0::ImageLayout::TRANSFER_DST_OPTIMAL,
+            RawLayout::Present => vk1_0::ImageLayout::PRESENT_SRC_KHR,
         }
     }
 }
 
-impl ToErupt<vk1_0::ImageLayout> for Option<Layout> {
+impl ToErupt<vk1_0::ImageLayout> for Option<RawLayout> {
     fn to_erupt(self) -> vk1_0::ImageLayout {
         match self {
             None => vk1_0::ImageLayout::UNDEFINED,
@@ -1328,93 +1328,6 @@ impl ToErupt<vk1_0::DescriptorSetLayoutCreateFlags> for DescriptorSetLayoutFlags
 
         if self.contains(DescriptorSetLayoutFlags::PUSH_DESCRIPTOR) {
             result |= vk1_0::DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR_KHR
-        }
-
-        result
-    }
-}
-
-impl ToErupt<vk1_0::AccessFlags> for AccessFlags {
-    fn to_erupt(self) -> vk1_0::AccessFlags {
-        let mut result = vk1_0::AccessFlags::empty();
-
-        if self.contains(Self::INDIRECT_COMMAND_READ) {
-            result |= vk1_0::AccessFlags::INDIRECT_COMMAND_READ;
-        }
-        if self.contains(Self::INDEX_READ) {
-            result |= vk1_0::AccessFlags::INDEX_READ;
-        }
-        if self.contains(Self::VERTEX_ATTRIBUTE_READ) {
-            result |= vk1_0::AccessFlags::VERTEX_ATTRIBUTE_READ;
-        }
-        if self.contains(Self::UNIFORM_READ) {
-            result |= vk1_0::AccessFlags::UNIFORM_READ;
-        }
-        if self.contains(Self::INPUT_ATTACHMENT_READ) {
-            result |= vk1_0::AccessFlags::INPUT_ATTACHMENT_READ;
-        }
-        if self.contains(Self::SHADER_READ) {
-            result |= vk1_0::AccessFlags::SHADER_READ;
-        }
-        if self.contains(Self::SHADER_WRITE) {
-            result |= vk1_0::AccessFlags::SHADER_WRITE;
-        }
-        if self.contains(Self::COLOR_ATTACHMENT_READ) {
-            result |= vk1_0::AccessFlags::COLOR_ATTACHMENT_READ;
-        }
-        if self.contains(Self::COLOR_ATTACHMENT_WRITE) {
-            result |= vk1_0::AccessFlags::COLOR_ATTACHMENT_WRITE;
-        }
-        if self.contains(Self::DEPTH_STENCIL_ATTACHMENT_READ) {
-            result |= vk1_0::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ;
-        }
-        if self.contains(Self::DEPTH_STENCIL_ATTACHMENT_WRITE) {
-            result |= vk1_0::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE;
-        }
-        if self.contains(Self::TRANSFER_READ) {
-            result |= vk1_0::AccessFlags::TRANSFER_READ;
-        }
-        if self.contains(Self::TRANSFER_WRITE) {
-            result |= vk1_0::AccessFlags::TRANSFER_WRITE;
-        }
-        if self.contains(Self::HOST_READ) {
-            result |= vk1_0::AccessFlags::HOST_READ;
-        }
-        if self.contains(Self::HOST_WRITE) {
-            result |= vk1_0::AccessFlags::HOST_WRITE;
-        }
-        if self.contains(Self::MEMORY_READ) {
-            result |= vk1_0::AccessFlags::MEMORY_READ;
-        }
-        if self.contains(Self::MEMORY_WRITE) {
-            result |= vk1_0::AccessFlags::MEMORY_WRITE;
-        }
-        // if self.contains(Self::TRANSFORM_FEEDBACK_WRITE) {
-        //     result |= vk1_0::AccessFlags::TRANSFORM_FEEDBACK_WRITE_EXT;
-        // }
-        // if self.contains(Self::TRANSFORM_FEEDBACK_COUNTER_READ) {
-        //     result |= vk1_0::AccessFlags::TRANSFORM_FEEDBACK_COUNTER_READ_EXT;
-        // }
-        // if self.contains(Self::TRANSFORM_FEEDBACK_COUNTER_WRITE) {
-        //     result |= vk1_0::AccessFlags::TRANSFORM_FEEDBACK_COUNTER_WRITE_EXT;
-        // }
-        if self.contains(Self::CONDITIONAL_RENDERING_READ) {
-            result |= vk1_0::AccessFlags::CONDITIONAL_RENDERING_READ_EXT;
-        }
-        if self.contains(Self::COLOR_ATTACHMENT_READ_NONCOHERENT) {
-            result |= vk1_0::AccessFlags::COLOR_ATTACHMENT_READ_NONCOHERENT_EXT;
-        }
-        if self.contains(Self::ACCELERATION_STRUCTURE_READ) {
-            result |= vk1_0::AccessFlags::ACCELERATION_STRUCTURE_READ_KHR;
-        }
-        if self.contains(Self::ACCELERATION_STRUCTURE_WRITE) {
-            result |= vk1_0::AccessFlags::ACCELERATION_STRUCTURE_WRITE_KHR;
-        }
-        if self.contains(Self::FRAGMENT_DENSITY_MAP_READ) {
-            result |= vk1_0::AccessFlags::FRAGMENT_DENSITY_MAP_READ_EXT;
-        }
-        if self.contains(Self::FRAGMENT_SHADING_RATE_ATTACHMENT_READ) {
-            result |= vk1_0::AccessFlags::FRAGMENT_SHADING_RATE_ATTACHMENT_READ_KHR;
         }
 
         result

--- a/src/backend/vulkan/encode.rs
+++ b/src/backend/vulkan/encode.rs
@@ -1,9 +1,9 @@
 use {
     super::{
-        access::supported_access,
         convert::{oom_error_from_erupt, ToErupt},
         device::WeakDevice,
         epochs::References,
+        sync,
     },
     crate::{
         accel::{AccelerationStructureGeometry, AccelerationStructureLevel, IndexData},
@@ -685,82 +685,53 @@ impl CommandBuffer {
                 },
 
                 Command::PipelineBarrier {
-                    src,
-                    dst,
                     images,
                     buffers,
-                    memory,
+                    global,
                 } => unsafe {
-                    for barrier in images {
+                    let mut src_stages = vk1_0::PipelineStageFlags::empty();
+                    let mut dst_stages = vk1_0::PipelineStageFlags::empty();
+
+                    let image_barriers = scope.to_scope_from_iter(images.iter().map(|barrier| {
                         assert_owner!(barrier.image, device);
                         self.references.add_image(barrier.image.clone());
-                    }
-                    for barrier in buffers {
+                        let (src_stg, dst_stg, image_barrier) = sync::get_image_memory_barrier(barrier);
+
+                        src_stages |= src_stg;
+                        dst_stages |= dst_stg;
+
+                        image_barrier
+                    }));
+
+                    let buffer_barriers = scope.to_scope_from_iter(buffers.iter().map(|barrier| {
                         assert_owner!(barrier.buffer, device);
                         self.references.add_buffer(barrier.buffer.clone());
-                    }
+
+                        let (src_stg, dst_stg, buffer_barrier) = sync::get_buffer_memory_barrier(barrier);
+
+                        src_stages |= src_stg;
+                        dst_stages |= dst_stg;
+
+                        buffer_barrier
+                    }));
+
+                    let global = global.map(|global| {
+                        let (src_stg, dst_stg, global_barrier) = sync::get_global_barrier(&global);
+
+                        src_stages |= src_stg;
+                        dst_stages |= dst_stg;
+
+                        global_barrier
+                    });
 
                     logical.cmd_pipeline_barrier(
                         self.handle,
-                        src.to_erupt(),
-                        dst.to_erupt(),
+                        src_stages,
+                        dst_stages,
                         None,
-                        &[vk1_0::MemoryBarrierBuilder::new()
-                            .src_access_mask(
-                                memory
-                                    .as_ref()
-                                    .map_or(supported_access(src.to_erupt()), |m| m.src.to_erupt()),
-                            )
-                            .dst_access_mask(
-                                memory
-                                    .as_ref()
-                                    .map_or(supported_access(dst.to_erupt()), |m| m.dst.to_erupt()),
-                            )],
-                        scope.to_scope_from_iter(buffers.iter().map(|buffer| {
-                            vk1_0::BufferMemoryBarrierBuilder::new()
-                                .buffer(buffer.buffer.handle())
-                                .offset(buffer.offset)
-                                .size(buffer.size)
-                                .src_access_mask(buffer.old_access.to_erupt())
-                                .dst_access_mask(buffer.new_access.to_erupt())
-                                .src_queue_family_index(
-                                    buffer
-                                        .family_transfer
-                                        .as_ref()
-                                        .map(|r| r.0)
-                                        .unwrap_or(vk1_0::QUEUE_FAMILY_IGNORED),
-                                )
-                                .dst_queue_family_index(
-                                    buffer
-                                        .family_transfer
-                                        .as_ref()
-                                        .map(|r| r.1)
-                                        .unwrap_or(vk1_0::QUEUE_FAMILY_IGNORED),
-                                )
-                        })),
-                        scope.to_scope_from_iter(images.iter().map(|image| {
-                            vk1_0::ImageMemoryBarrierBuilder::new()
-                                .image(image.image.handle())
-                                .subresource_range(image.range.to_erupt())
-                                .src_access_mask(image.old_access.to_erupt())
-                                .dst_access_mask(image.new_access.to_erupt())
-                                .old_layout(image.old_layout.to_erupt())
-                                .new_layout(image.new_layout.to_erupt())
-                                .src_queue_family_index(
-                                    image
-                                        .family_transfer
-                                        .as_ref()
-                                        .map(|r| r.0)
-                                        .unwrap_or(vk1_0::QUEUE_FAMILY_IGNORED),
-                                )
-                                .dst_queue_family_index(
-                                    image
-                                        .family_transfer
-                                        .as_ref()
-                                        .map(|r| r.1)
-                                        .unwrap_or(vk1_0::QUEUE_FAMILY_IGNORED),
-                                )
-                        })),
+                        scope.to_scope_from_iter(global.into_iter()),
+                        buffer_barriers,
+                        image_barriers,
                     )
                 },
                 Command::PushConstants {

--- a/src/backend/vulkan/mod.rs
+++ b/src/backend/vulkan/mod.rs
@@ -14,6 +14,7 @@ mod physical;
 mod queue;
 mod resources;
 mod surface;
+mod sync;
 mod swapchain;
 
 pub use self::{

--- a/src/backend/vulkan/sync.rs
+++ b/src/backend/vulkan/sync.rs
@@ -1,0 +1,202 @@
+// Modified from vk-sync-rs, originally Copyright 2019 Graham Wihlidal
+// licensed under MIT license.
+//
+// https://github.com/gwihlidal/vk-sync-rs/blob/master/LICENSE-MIT
+
+use crate::{BufferMemoryBarrier, GlobalMemoryBarrier, ImageMemoryBarrier, Layout};
+use super::{access::GetAccessInfo, convert::ToErupt};
+
+use erupt::vk1_0;
+
+/// Mapping function that translates a global barrier into a set of source and
+/// destination pipeline stages, and a memory barrier, that can be used with
+/// Vulkan synchronization methods.
+pub fn get_global_barrier<'a>(
+	barrier: &GlobalMemoryBarrier,
+) -> (
+	vk1_0::PipelineStageFlags,
+	vk1_0::PipelineStageFlags,
+	vk1_0::MemoryBarrierBuilder<'a>,
+) {
+	let mut src_stages = vk1_0::PipelineStageFlags::empty();
+	let mut dst_stages = vk1_0::PipelineStageFlags::empty();
+
+	let mut src_access_mask = vk1_0::AccessFlags::empty();
+	let mut dst_access_mask = vk1_0::AccessFlags::empty();
+
+	for prev_access in barrier.prev_accesses {
+		let previous_info = prev_access.access_info();
+
+		src_stages |= previous_info.stage_mask;
+
+		// Add appropriate availability operations - for writes only.
+		if prev_access.is_write() {
+			src_access_mask |= previous_info.access_mask;
+		}
+	}
+
+	for next_access in barrier.next_accesses {
+		let next_info = next_access.access_info();
+
+		dst_stages |= next_info.stage_mask;
+
+		// Add visibility operations as necessary.
+		// If the src access mask, this is a WAR hazard (or for some reason a "RAR"),
+		// so the dst access mask can be safely zeroed as these don't need visibility.
+		if src_access_mask != vk1_0::AccessFlags::empty() {
+			dst_access_mask |= next_info.access_mask;
+		}
+	}
+
+	// Ensure that the stage masks are valid if no stages were determined
+	if src_stages == vk1_0::PipelineStageFlags::empty() {
+		src_stages = vk1_0::PipelineStageFlags::TOP_OF_PIPE;
+	}
+
+	if dst_stages == vk1_0::PipelineStageFlags::empty() {
+		dst_stages = vk1_0::PipelineStageFlags::BOTTOM_OF_PIPE;
+	}
+
+	let memory_barrier = vk1_0::MemoryBarrierBuilder::new()
+		.src_access_mask(src_access_mask)
+		.dst_access_mask(dst_access_mask);
+
+	(src_stages, dst_stages, memory_barrier)
+}
+
+/// Mapping function that translates a buffer barrier into a set of source and
+/// destination pipeline stages, and a buffer memory barrier, that can be used
+/// with Vulkan synchronization methods.
+pub fn get_buffer_memory_barrier<'a>(
+	barrier: &BufferMemoryBarrier,
+) -> (
+	vk1_0::PipelineStageFlags,
+	vk1_0::PipelineStageFlags,
+	vk1_0::BufferMemoryBarrierBuilder<'a>,
+) {
+	let mut src_stages = vk1_0::PipelineStageFlags::empty();
+	let mut dst_stages = vk1_0::PipelineStageFlags::empty();
+
+	let mut src_access_mask = vk1_0::AccessFlags::empty();
+	let mut dst_access_mask = vk1_0::AccessFlags::empty();
+
+	let (src_queue_family_index, dst_queue_family_index) = barrier
+		.family_transfer
+		.unwrap_or((vk1_0::QUEUE_FAMILY_IGNORED, vk1_0::QUEUE_FAMILY_IGNORED));
+
+
+	let previous_info = barrier.prev_access.access_info();
+
+	src_stages |= previous_info.stage_mask;
+
+	// Add appropriate availability operations - for writes only.
+	if barrier.prev_access.is_write() {
+		src_access_mask |= previous_info.access_mask;
+	}
+
+	let next_info = barrier.next_access.access_info();
+
+	dst_stages |= next_info.stage_mask;
+
+	// Add visibility operations as necessary.
+	// If the src access mask, this is a WAR hazard (or for some reason a "RAR"),
+	// so the dst access mask can be safely zeroed as these don't need visibility.
+	if src_access_mask != vk1_0::AccessFlags::empty() {
+		dst_access_mask |= next_info.access_mask;
+	}
+
+	// Ensure that the stage masks are valid if no stages were determined
+	if src_stages == vk1_0::PipelineStageFlags::empty() {
+		src_stages = vk1_0::PipelineStageFlags::TOP_OF_PIPE;
+	}
+
+	if dst_stages == vk1_0::PipelineStageFlags::empty() {
+		dst_stages = vk1_0::PipelineStageFlags::BOTTOM_OF_PIPE;
+	}
+
+	let buffer_barrier = vk1_0::BufferMemoryBarrierBuilder::new()
+		.src_queue_family_index(src_queue_family_index)
+		.dst_queue_family_index(dst_queue_family_index)
+		.buffer(barrier.buffer.handle())
+		.offset(barrier.offset as u64)
+		.size(barrier.size as u64);
+
+	(src_stages, dst_stages, buffer_barrier)
+}
+
+/// Mapping function that translates an image barrier into a set of source and
+/// destination pipeline stages, and an image memory barrier, that can be used
+/// with Vulkan synchronization methods.
+pub fn get_image_memory_barrier<'a>(
+	barrier: &ImageMemoryBarrier,
+) -> (
+	vk1_0::PipelineStageFlags,
+	vk1_0::PipelineStageFlags,
+	vk1_0::ImageMemoryBarrierBuilder<'a>,
+) {
+	let mut src_stages = vk1_0::PipelineStageFlags::empty();
+	let mut dst_stages = vk1_0::PipelineStageFlags::empty();
+
+	let mut src_access_mask = vk1_0::AccessFlags::empty();
+	let mut dst_access_mask = vk1_0::AccessFlags::empty();
+
+	let (src_queue_family_index, dst_queue_family_index) = barrier
+		.family_transfer
+		.unwrap_or((vk1_0::QUEUE_FAMILY_IGNORED, vk1_0::QUEUE_FAMILY_IGNORED));
+
+	let previous_info = barrier.prev_access.access_info();
+
+	src_stages |= previous_info.stage_mask;
+
+	// Add appropriate availability operations - for writes only.
+	if barrier.prev_access.is_write() {
+		src_access_mask |= previous_info.access_mask;
+	}
+
+	let old_layout = if let Some(barrier_old_layout) = barrier.old_layout {
+		match barrier_old_layout {
+			Layout::Optimal => previous_info.image_layout,
+			Layout::Manual(layout) => layout.to_erupt(),
+		}
+	} else {
+		vk1_0::ImageLayout::UNDEFINED
+	};
+
+	let next_info = barrier.next_access.access_info();
+
+	dst_stages |= next_info.stage_mask;
+
+	// Add visibility operations as necessary.
+	// If the src access mask, this is a WAR hazard (or for some reason a "RAR"),
+	// so the dst access mask can be safely zeroed as these don't need visibility.
+	if src_access_mask != vk1_0::AccessFlags::empty() {
+		dst_access_mask |= next_info.access_mask;
+	}
+
+	let new_layout = match barrier.new_layout {
+		Layout::Optimal => next_info.image_layout,
+		Layout::Manual(layout) => layout.to_erupt(),
+	};
+
+	// Ensure that the stage masks are valid if no stages were determined
+	if src_stages == vk1_0::PipelineStageFlags::empty() {
+		src_stages = vk1_0::PipelineStageFlags::TOP_OF_PIPE;
+	}
+
+	if dst_stages == vk1_0::PipelineStageFlags::empty() {
+		dst_stages = vk1_0::PipelineStageFlags::BOTTOM_OF_PIPE;
+	}
+
+	let image_barrier = vk1_0::ImageMemoryBarrierBuilder::new()
+		.src_queue_family_index(src_queue_family_index)
+		.dst_queue_family_index(dst_queue_family_index)
+		.image(barrier.image.handle())
+		.subresource_range(barrier.range.to_erupt())
+		.src_access_mask(src_access_mask)
+		.dst_access_mask(dst_access_mask)
+		.old_layout(old_layout)
+		.new_layout(new_layout);
+
+
+	(src_stages, dst_stages, image_barrier)
+}

--- a/src/descriptor/image.rs
+++ b/src/descriptor/image.rs
@@ -1,7 +1,7 @@
 use {
     super::{DescriptorBindingFlags, ImageViewDescriptor, TypedDescriptorBinding},
     crate::{
-        image::{Image, Layout},
+        image::{Image, RawLayout},
         view::{ImageView, ImageViewInfo},
         Device, OutOfMemory,
     },
@@ -20,7 +20,7 @@ impl TypedDescriptorBinding for Image {
         let view = device.create_image_view(ImageViewInfo::new(self.clone()))?;
         Ok([ImageViewDescriptor {
             view,
-            layout: Layout::ShaderReadOnlyOptimal,
+            layout: RawLayout::ShaderReadOnlyOptimal,
         }])
     }
 }
@@ -37,7 +37,7 @@ impl TypedDescriptorBinding for ImageView {
     fn get_descriptors(&self, _device: &Device) -> Result<[ImageViewDescriptor; 1], OutOfMemory> {
         Ok([ImageViewDescriptor {
             view: self.clone(),
-            layout: Layout::ShaderReadOnlyOptimal,
+            layout: RawLayout::ShaderReadOnlyOptimal,
         }])
     }
 }
@@ -74,7 +74,7 @@ impl<const N: usize> TypedDescriptorBinding for [ImageView; N] {
             unsafe {
                 result.push_unchecked(ImageViewDescriptor {
                     view: me.clone(),
-                    layout: Layout::ShaderReadOnlyOptimal,
+                    layout: RawLayout::ShaderReadOnlyOptimal,
                 });
             }
         }
@@ -120,7 +120,7 @@ impl<const N: usize> TypedDescriptorBinding for arrayvec::ArrayVec<ImageView, N>
             unsafe {
                 result.push_unchecked(ImageViewDescriptor {
                     view: me.clone(),
-                    layout: Layout::ShaderReadOnlyOptimal,
+                    layout: RawLayout::ShaderReadOnlyOptimal,
                 });
             }
         }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     buffer::BufferRange,
     encode::Encoder,
     // image::Image,
-    image::Layout,
+    image::RawLayout,
     // image::{ImageExtent, SubresourceRange},
     sampler::Sampler,
     view::ImageView,
@@ -74,7 +74,7 @@ pub struct ImageViewDescriptor {
     pub view: ImageView,
 
     /// View's layout when descriptor is accessed.
-    pub layout: Layout,
+    pub layout: RawLayout,
 }
 
 /// Image view, layout and sampler.\
@@ -86,7 +86,7 @@ pub struct CombinedImageSampler {
     pub view: ImageView,
 
     /// View's layout when descriptor is accessed.
-    pub layout: Layout,
+    pub layout: RawLayout,
 
     /// Descriptor sampler resource.
     pub sampler: Sampler,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,4 +1,4 @@
-use crate::access::AccessFlags;
+use crate::access::Access;
 
 bitflags::bitflags! {
     /// Memory usage type.
@@ -25,8 +25,15 @@ bitflags::bitflags! {
     }
 }
 
+/// Global barriers define a set of accesses on multiple resources at once.
+/// If a buffer or image doesn't require a queue ownership transfer, or an image
+/// doesn't require a layout transition (e.g. you're using one of the
+/// `ImageLayout::General*` layouts) then a global barrier should be preferred.
+///
+/// Simply define the previous and next access types of resources affected.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-pub struct MemoryBarrier {
-    pub src: AccessFlags,
-    pub dst: AccessFlags,
+pub struct GlobalMemoryBarrier<'a> {
+    pub prev_accesses: &'a [Access],
+    pub next_accesses: &'a [Access],
+
 }

--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -3,7 +3,7 @@ use crate::{
     encode::{Encoder, RenderPassEncoder},
     format::Format,
     framebuffer::FramebufferError,
-    image::{Layout, Samples},
+    image::{RawLayout, Samples},
     stage::PipelineStageFlags,
     Device, OutOfMemory,
 };
@@ -58,13 +58,13 @@ pub struct AttachmentInfo {
         feature = "serde-1",
         serde(skip_serializing_if = "Option::is_none", default)
     )]
-    pub initial_layout: Option<Layout>,
+    pub initial_layout: Option<RawLayout>,
 
     #[cfg_attr(
         feature = "serde-1",
         serde(skip_serializing_if = "is_default", default)
     )]
-    pub final_layout: Layout,
+    pub final_layout: RawLayout,
 }
 
 /// Specifies how render pass treats attachment content at the beginning.
@@ -128,7 +128,7 @@ pub struct Subpass {
         feature = "serde-1",
         serde(skip_serializing_if = "Vec::is_empty", default)
     )]
-    pub colors: Vec<(u32, Layout)>,
+    pub colors: Vec<(u32, RawLayout)>,
 
     /// Index of an attachment that is used as depth attachment in this
     /// subpass.
@@ -136,7 +136,7 @@ pub struct Subpass {
         feature = "serde-1",
         serde(skip_serializing_if = "Option::is_none", default)
     )]
-    pub depth: Option<(u32, Layout)>,
+    pub depth: Option<(u32, RawLayout)>,
 }
 
 /// Defines memory dependency between two subpasses

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,11 +1,10 @@
 pub use crate::backend::ImageView;
 use crate::{
-    access::AccessFlags,
+    access::Access,
     backend::Device,
     encode::Encoder,
     image::{Image, ImageExtent, ImageMemoryBarrier, Layout, SubresourceRange},
     queue::{Ownership, QueueId},
-    stage::PipelineStageFlags,
     OutOfMemory,
 };
 
@@ -82,18 +81,17 @@ impl MakeImageView for Image {
 }
 
 /// Image region with access mask,
-/// specifying how it may be accessed "before".
+/// specifying how it was accessed "before".
 ///
-/// Note that "before" is loosely defined,
-/// as whatever previous owners do.
-/// Which should be translated to "earlier GPU operations"
+/// Note that "before" is loosely defined
+/// as whatever previous owners did with it,
+/// i.e. "earlier GPU operations which used this resource,"
 /// but this crate doesn't attempt to enforce that.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ImageViewState {
     pub view: ImageView,
-    pub access: AccessFlags,
-    pub stages: PipelineStageFlags,
-    pub layout: Option<Layout>,
+    pub prev_access: Access,
+    pub old_layout: Option<Layout>,
     pub family: Ownership,
 }
 
@@ -101,22 +99,19 @@ impl ImageViewState {
     ///
     pub fn access<'a>(
         &'a mut self,
-        access: AccessFlags,
-        stages: PipelineStageFlags,
-        layout: Layout,
+        next_access: Access,
+        new_layout: Layout,
         queue: QueueId,
         encoder: &mut Encoder<'a>,
     ) -> &'a ImageView {
         match self.family {
             Ownership::NotOwned => encoder.image_barriers(
-                self.stages,
-                stages,
                 encoder.scope().to_scope([ImageMemoryBarrier {
                     image: &self.view.info().image,
-                    old_access: self.access,
-                    new_access: access,
-                    old_layout: self.layout,
-                    new_layout: layout,
+                    prev_access: self.prev_access,
+                    next_access,
+                    old_layout: self.old_layout,
+                    new_layout,
                     family_transfer: None,
                     range: self.view.info().range,
                 }]),
@@ -125,14 +120,12 @@ impl ImageViewState {
                 assert_eq!(family, queue.family, "Wrong queue family owns the buffer");
 
                 encoder.image_barriers(
-                    self.stages,
-                    stages,
                     encoder.scope().to_scope([ImageMemoryBarrier {
                         image: &self.view.info().image,
-                        old_access: self.access,
-                        new_access: access,
-                        old_layout: self.layout,
-                        new_layout: layout,
+                        prev_access: self.prev_access,
+                        next_access,
+                        old_layout: self.old_layout,
+                        new_layout,
                         family_transfer: None,
                         range: self.view.info().range,
                     }]),
@@ -145,14 +138,12 @@ impl ImageViewState {
                 );
 
                 encoder.image_barriers(
-                    self.stages,
-                    stages,
                     encoder.scope().to_scope([ImageMemoryBarrier {
                         image: &self.view.info().image,
-                        old_access: self.access,
-                        new_access: access,
-                        old_layout: self.layout,
-                        new_layout: layout,
+                        prev_access: self.prev_access,
+                        next_access,
+                        old_layout: self.old_layout,
+                        new_layout,
                         family_transfer: Some((from, to)),
                         range: self.view.info().range,
                     }]),
@@ -162,30 +153,26 @@ impl ImageViewState {
         self.family = Ownership::Owned {
             family: queue.family,
         };
-        self.stages = stages;
-        self.access = access;
-        self.layout = Some(layout);
+        self.prev_access = next_access;
+        self.old_layout = Some(new_layout);
         &self.view
     }
 
     ///
     pub fn overwrite<'a>(
         &'a mut self,
-        access: AccessFlags,
-        stages: PipelineStageFlags,
-        layout: Layout,
+        next_access: Access,
+        new_layout: Layout,
         queue: QueueId,
         encoder: &mut Encoder<'a>,
     ) -> &'a ImageView {
         encoder.image_barriers(
-            self.stages,
-            stages,
             encoder.scope().to_scope([ImageMemoryBarrier {
                 image: &self.view.info().image,
-                old_access: AccessFlags::empty(),
-                new_access: access,
+                prev_access: Access::None,
+                next_access,
                 old_layout: None,
-                new_layout: layout,
+                new_layout,
                 family_transfer: None,
                 range: self.view.info().range,
             }]),
@@ -193,9 +180,8 @@ impl ImageViewState {
         self.family = Ownership::Owned {
             family: queue.family,
         };
-        self.stages = stages;
-        self.access = access;
-        self.layout = Some(layout);
+        self.prev_access = next_access;
+        self.old_layout = Some(new_layout);
         &self.view
     }
 }


### PR DESCRIPTION
I think this fits with the ethos of `sierra` in simplifying Vulkan concepts while still remaining as flexible/usable as possible. We've been using similar sort of sync primitives at Embark for a little while now and it's been working quite well and feels nice. I know this is a pretty large change so feel free to give feedback or just say if it doesn't fit in your vision for the lib.